### PR TITLE
Fix Pages deploy: bump actions off deprecated upload-artifact v3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,15 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install, build, and upload your site
-        uses: withastro/action@v0
+        uses: withastro/action@v3
         with:
           node-version: 21
-       # with:
-            # path: . # The root location of your Astro project inside the repository. (optional)
-            # node-version: 16 # The specific version of Node that should be used to build your site. Defaults to 16. (optional)
-            # package-manager: yarn # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
+          # path: .            # Root of the Astro project inside the repo (optional)
+          # package-manager: npm # Auto-detected from the lockfile (optional)
 
   deploy:
     needs: build
@@ -38,9 +36,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
-        with:
-          clean: true
-          clean-exclude: |
-            CNAME
+        uses: actions/deploy-pages@v4
 


### PR DESCRIPTION
## Problema

El despliegue automático a GitHub Pages falla con:

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`.

La causa es que `.github/workflows/deploy.yml` usa versiones antiguas de las actions (`withastro/action@v0`, `actions/deploy-pages@v1`) que internamente dependen de `actions/upload-artifact@v3`, ahora autofallado por GitHub.

## Solución

| Action | Antes | Ahora |
|---|---|---|
| `actions/checkout` | v3 | v4 |
| `withastro/action` | v0 | v3 |
| `actions/deploy-pages` | v1 | v4 |

Las versiones nuevas usan `actions/upload-artifact@v4` internamente, eliminando el error.

También se eliminan los inputs `clean` / `clean-exclude` del paso `actions/deploy-pages`: esa action nunca los soportó (eran no-ops). El dominio personalizado se mantiene vía *Settings → Pages* del repo.

## Notas
- Diff aislado: solo toca `.github/workflows/deploy.yml`.
- El workflow solo se dispara en push a `main` o `workflow_dispatch`, así que el fix se valida al hacer merge (o lanzándolo manualmente desde la pestaña Actions).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAWLwfV1853QjEUjb9ocDf)_