### PR TITLE
Refocus landing as personal intro + UX refresh (mobile-first, dark mode)

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -44,6 +44,7 @@ const personSchema = {
 <!-- Global Metadata -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
+<meta name="color-scheme" content="light dark" />
 <link rel="icon" type="image/x-icon" href="/favicon.ico" />
 <link rel="apple-touch-icon" href="/favicon.ico" />
 <meta name="theme-color" content="#ffffff" />

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -3,11 +3,15 @@ const today = new Date();
 ---
 
 <footer>
-	&copy; {today.getFullYear()} Leonardo Esparis. All rights reserved.
+	&copy; {today.getFullYear()} Leonardo Esparis
 </footer>
 <style>
 	footer {
-		padding: 25px;
-		text-align: center;
+		margin-top: 56px;
+		padding: 24px 0;
+		border-top: 1px solid var(--border);
+		color: var(--text-soft);
+		font-size: 0.85rem;
+		text-align: left;
 	}
 </style>

--- a/src/components/HomeContent.astro
+++ b/src/components/HomeContent.astro
@@ -15,12 +15,13 @@ const t = getContent(lang);
 
 <!-- Hero -->
 <section class="hero">
-    <p class="hero-role">{t.hero.role}</p>
-    <h1 class="hero-name">{t.hero.name}</h1>
-    <p class="hero-tagline">{t.hero.tagline}</p>
-    <div class="hero-cta">
-        <a class="btn btn-primary" href="#contact">{t.hero.ctaPrimary}</a>
-        <a class="btn btn-secondary" href="#projects">{t.hero.ctaSecondary}</a>
+    <div class="hero-inner">
+        <p class="hero-role">{t.hero.role}</p>
+        <h1 class="hero-name">{t.hero.name}</h1>
+        <p class="hero-tagline">{t.hero.tagline}</p>
+        <div class="hero-cta">
+            <a class="btn btn-primary" href="#contact">{t.hero.ctaPrimary}</a>
+        </div>
     </div>
 </section>
 
@@ -30,75 +31,34 @@ const t = getContent(lang);
     {t.about.paragraphs.map((p) => <p>{p}</p>)}
 </section>
 
-<!-- Experience -->
-<section id="experience" class="section">
-    <h2>{t.experience.heading}</h2>
-    <ol class="timeline">
-        {
-            t.experience.items.map((item) => (
-                <li class="timeline-item">
-                    <div class="timeline-head">
-                        <strong>{item.role}</strong>
-                        <span class="timeline-company">{item.company}</span>
-                    </div>
-                    <div class="timeline-meta">
-                        <span>{item.period}</span>
-                        <span>{item.location}</span>
-                    </div>
-                    <ul>
-                        {item.highlights.map((h) => (
-                            <li>{h}</li>
-                        ))}
-                    </ul>
-                </li>
-            ))
-        }
-    </ol>
-</section>
+{/*
+  Featured projects — Hidden for now. Uncomment to re-enable (data lives in
+  src/i18n/{en,es}.ts under `projects`; styles in global.css under .projects-grid).
 
-<!-- Tech stack -->
-<section id="skills" class="section">
-    <h2>{t.skills.heading}</h2>
-    <div class="skills-grid">
-        {
-            t.skills.groups.map((group) => (
-                <div class="skill-group">
-                    <h3>{group.name}</h3>
-                    <ul class="tag-list">
-                        {group.items.map((item) => (
-                            <li class="tag">{item}</li>
-                        ))}
-                    </ul>
-                </div>
-            ))
-        }
-    </div>
-</section>
-
-<!-- Featured projects -->
-<section id="projects" class="section">
-    <h2>{t.projects.heading}</h2>
-    <div class="projects-grid">
-        {
-            t.projects.items.map((project) => (
-                <a
-                    class="project-card"
-                    href={project.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                >
-                    <h3>{project.name}</h3>
-                    <p>{project.description}</p>
-                    <ul class="tag-list">
-                        {project.tags.map((tag) => (
-                            <li class="tag">{tag}</li>
-                        ))}
-                    </ul>
-                </a>
-            ))
-        }
-    </div>
-</section>
+  <section id="projects" class="section">
+      <h2>{t.projects.heading}</h2>
+      <div class="projects-grid">
+          {
+              t.projects.items.map((project) => (
+                  <a
+                      class="project-card"
+                      href={project.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                  >
+                      <h3>{project.name}</h3>
+                      <p>{project.description}</p>
+                      <ul class="tag-list">
+                          {project.tags.map((tag) => (
+                              <li class="tag">{tag}</li>
+                          ))}
+                      </ul>
+                  </a>
+              ))
+          }
+      </div>
+  </section>
+*/}
 
 <!-- Contact -->
 <section id="contact" class="section">

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -2,14 +2,14 @@
 // Visible copy lives in the per-language dictionaries (src/i18n/en.ts, es.ts).
 
 // Fallbacks used when a page does not pass its own title/description.
-export const SITE_TITLE = 'Leonardo Esparis — Software Engineer';
+export const SITE_TITLE = 'Leonardo Esparis — Senior Software Engineer';
 export const SITE_DESCRIPTION =
-    'Leonardo Esparis, software engineer experienced building reliable, high-traffic systems. Explore my experience, tech stack and projects.';
+    'Leonardo Esparis, senior software engineer with 8+ years building backends — highly concurrent, event-driven, distributed systems in Python.';
 
 // Personal identity, used for the JSON-LD Person schema and contact links.
 export const PERSON = {
     name: 'Leonardo Esparis',
-    jobTitle: 'Software Engineer',
+    jobTitle: 'Senior Software Engineer',
     email: 'ljesparis@gmail.com',
     // Profiles power JSON-LD `sameAs` so search engines can link your identity.
     linkedin: 'https://www.linkedin.com/in/leoesparis/',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1,80 +1,34 @@
 // English content dictionary.
-// NOTE: Strings prefixed with "TODO:" are placeholders. Replace them with the
-// real content (bio, experience, skills, projects) before going live.
 import type { SiteContent } from './types';
 
 export const en: SiteContent = {
     // Per-page SEO metadata.
     meta: {
-        title: 'Leonardo Esparis — Software Engineer',
+        title: 'Leonardo Esparis — Senior Software Engineer',
         description:
-            'Leonardo Esparis, software engineer experienced building reliable, high-traffic systems. Explore my experience, tech stack and projects.'
+            'Leonardo Esparis, senior software engineer with 8+ years building backends — highly concurrent, event-driven, distributed systems in Python.'
     },
 
-    // Top navigation labels.
-    nav: {
-        about: 'About',
-        experience: 'Experience',
-        skills: 'Tech stack',
-        projects: 'Projects',
-        contact: 'Contact'
-    },
-
-    // Language switcher label (shown for the link to the OTHER language).
-    languageName: 'English',
+    // Language switcher label (link to the OTHER language).
     switchToLabel: 'Español',
 
     hero: {
         name: 'Leonardo Esparis',
-        role: 'Software Engineer',
-        // One-line value proposition. Keep it punchy and concrete.
+        role: 'Senior Software Engineer',
         tagline:
-            'TODO: One sentence describing what you do and the value you bring (e.g. "I build scalable backend systems that serve millions of users").',
-        ctaPrimary: 'Get in touch',
-        ctaSecondary: 'View projects'
+            'I build the kind of systems that have to stay calm under pressure — and I love every part of the craft.',
+        ctaPrimary: 'Get in touch'
     },
 
     about: {
         heading: 'About me',
         paragraphs: [
-            'TODO: Paragraph 1 — who you are, your focus and what drives you as an engineer.',
-            'TODO: Paragraph 2 — the kind of problems you enjoy solving and the impact of your work.',
-            'TODO: Paragraph 3 (optional) — what you are exploring now or open to.'
+            "I'm Leonardo, a software engineer with 8+ years of building backends I'm genuinely proud of. I'm happiest working on highly concurrent, event-driven systems — the kind where distributed services on AWS pass messages through Kafka or RabbitMQ and everything has to stay coherent.",
+            "Most of my work lives in Python and Django, with a real soft spot for clean, maintainable design (DDD and hexagonal architecture feel like home). Part of my career has been spent on payment systems, where correctness really matters. I love building things, and I'm always stepping out of my comfort zone to learn new languages. Based in Madrid."
         ]
     },
 
-    experience: {
-        heading: 'Experience',
-        // Most recent first.
-        items: [
-            {
-                company: 'TODO: Company name',
-                role: 'TODO: Your role',
-                period: 'TODO: e.g. 2022 — Present',
-                location: 'TODO: City / Remote',
-                highlights: [
-                    'TODO: Achievement with measurable impact (numbers, scale, results).',
-                    'TODO: Key technology or responsibility.'
-                ]
-            }
-        ]
-    },
-
-    skills: {
-        heading: 'Tech stack',
-        // Group related technologies; add or remove groups freely.
-        groups: [
-            {
-                name: 'TODO: e.g. Languages',
-                items: ['TODO: Go', 'TODO: Python', 'TODO: TypeScript']
-            },
-            {
-                name: 'TODO: e.g. Infrastructure',
-                items: ['TODO: Docker', 'TODO: Kubernetes', 'TODO: AWS']
-            }
-        ]
-    },
-
+    // Hidden for now. Fill these in and re-enable the section in HomeContent.astro.
     projects: {
         heading: 'Featured projects',
         items: [
@@ -90,7 +44,7 @@ export const en: SiteContent = {
 
     contact: {
         heading: 'Get in touch',
-        text: 'TODO: A short line inviting people to reach out, then your channels below.',
+        text: "Got an interesting problem or idea? I'd be glad to hear from you.",
         emailLabel: 'Email me'
     }
 };

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -1,80 +1,34 @@
 // Diccionario de contenido en español.
-// NOTA: las cadenas con prefijo "TODO:" son marcadores. Sustitúyelas por el
-// contenido real (bio, experiencia, skills, proyectos) antes de publicar.
 import type { SiteContent } from './types';
 
 export const es: SiteContent = {
     // Metadatos SEO por página.
     meta: {
-        title: 'Leonardo Esparis — Ingeniero de Software',
+        title: 'Leonardo Esparis — Ingeniero de Software Senior',
         description:
-            'Leonardo Esparis, ingeniero de software con experiencia construyendo sistemas fiables y de alto tráfico. Conoce mi experiencia, stack y proyectos.'
-    },
-
-    // Etiquetas de la navegación.
-    nav: {
-        about: 'Sobre mí',
-        experience: 'Experiencia',
-        skills: 'Stack',
-        projects: 'Proyectos',
-        contact: 'Contacto'
+            'Leonardo Esparis, ingeniero de software senior con más de 8 años construyendo backends: sistemas distribuidos, altamente concurrentes y orientados a eventos en Python.'
     },
 
     // Selector de idioma (enlace al OTRO idioma).
-    languageName: 'Español',
     switchToLabel: 'English',
 
     hero: {
         name: 'Leonardo Esparis',
-        role: 'Ingeniero de Software',
-        // Propuesta de valor en una línea. Directa y concreta.
+        role: 'Ingeniero de Software Senior',
         tagline:
-            'TODO: Una frase que describa qué haces y el valor que aportas (p. ej. "Construyo sistemas backend escalables que sirven a millones de usuarios").',
-        ctaPrimary: 'Contáctame',
-        ctaSecondary: 'Ver proyectos'
+            'Construyo sistemas que tienen que mantener la calma bajo presión, y disfruto cada parte del oficio.',
+        ctaPrimary: 'Contáctame'
     },
 
     about: {
         heading: 'Sobre mí',
         paragraphs: [
-            'TODO: Párrafo 1 — quién eres, tu enfoque y qué te motiva como ingeniero.',
-            'TODO: Párrafo 2 — qué tipo de problemas te gusta resolver y el impacto de tu trabajo.',
-            'TODO: Párrafo 3 (opcional) — qué estás explorando ahora o a qué estás abierto.'
+            'Soy Leonardo, ingeniero de software con más de 8 años creando backends de los que estoy orgulloso. Donde mejor me siento es en sistemas altamente concurrentes y orientados a eventos: servicios distribuidos en AWS que intercambian mensajes mediante Kafka o RabbitMQ y donde todo tiene que mantenerse coherente.',
+            'La mayor parte de mi trabajo vive en Python y Django, con verdadera debilidad por el diseño limpio y mantenible (DDD y arquitectura hexagonal me resultan terreno conocido). Parte de mi carrera la he dedicado a sistemas de pagos, donde la corrección importa de verdad. Me encanta construir y salir de mi zona de confort aprendiendo nuevos lenguajes. Afincado en Madrid.'
         ]
     },
 
-    experience: {
-        heading: 'Experiencia',
-        // Más reciente primero.
-        items: [
-            {
-                company: 'TODO: Nombre de la empresa',
-                role: 'TODO: Tu rol',
-                period: 'TODO: p. ej. 2022 — Actualidad',
-                location: 'TODO: Ciudad / Remoto',
-                highlights: [
-                    'TODO: Logro con impacto medible (cifras, escala, resultados).',
-                    'TODO: Tecnología o responsabilidad clave.'
-                ]
-            }
-        ]
-    },
-
-    skills: {
-        heading: 'Stack tecnológico',
-        // Agrupa tecnologías relacionadas; añade o quita grupos libremente.
-        groups: [
-            {
-                name: 'TODO: p. ej. Lenguajes',
-                items: ['TODO: Go', 'TODO: Python', 'TODO: TypeScript']
-            },
-            {
-                name: 'TODO: p. ej. Infraestructura',
-                items: ['TODO: Docker', 'TODO: Kubernetes', 'TODO: AWS']
-            }
-        ]
-    },
-
+    // Oculto por ahora. Rellénalo y reactiva la sección en HomeContent.astro.
     projects: {
         heading: 'Proyectos destacados',
         items: [
@@ -90,7 +44,7 @@ export const es: SiteContent = {
 
     contact: {
         heading: 'Contacto',
-        text: 'TODO: Una línea breve invitando a escribirte, y debajo tus canales.',
+        text: '¿Tienes un problema o una idea interesante? Me encantará saber de ti.',
         emailLabel: 'Escríbeme'
     }
 };

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1,19 +1,8 @@
 // Shared shape for the per-language content dictionaries.
 // Both en.ts and es.ts implement this, keeping the two languages in sync.
 
-export interface ExperienceItem {
-    company: string;
-    role: string;
-    period: string;
-    location: string;
-    highlights: string[];
-}
-
-export interface SkillGroup {
-    name: string;
-    items: string[];
-}
-
+// Projects are hidden for now but kept here so the section can be re-enabled
+// without rebuilding its data model.
 export interface ProjectItem {
     name: string;
     description: string;
@@ -26,34 +15,19 @@ export interface SiteContent {
         title: string;
         description: string;
     };
-    nav: {
-        about: string;
-        experience: string;
-        skills: string;
-        projects: string;
-        contact: string;
-    };
-    languageName: string;
+    // Label for the link that switches to the other language.
     switchToLabel: string;
     hero: {
         name: string;
         role: string;
         tagline: string;
         ctaPrimary: string;
-        ctaSecondary: string;
     };
     about: {
         heading: string;
         paragraphs: string[];
     };
-    experience: {
-        heading: string;
-        items: ExperienceItem[];
-    };
-    skills: {
-        heading: string;
-        groups: SkillGroup[];
-    };
+    // Hidden for now — see HomeContent.astro.
     projects: {
         heading: string;
         items: ProjectItem[];

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,7 +3,7 @@ import BaseHead from '../components/BaseHead.astro';
 import Footer from '../components/Footer.astro';
 import GoogleAnalytics from '../components/GoogleAnalytics.astro';
 
-import { SOCIAL_LINKS } from '../consts';
+import { PERSON, SOCIAL_LINKS } from '../consts';
 import {
     getLangFromUrl,
     getContent,
@@ -22,17 +22,12 @@ const t = getContent(lang);
 const title = Astro.props.title ?? t.meta.title;
 const description = Astro.props.description ?? t.meta.description;
 
-// Anchor links within the single-page layout.
-const sectionLinks = [
-    { href: '#about', label: t.nav.about },
-    { href: '#experience', label: t.nav.experience },
-    { href: '#skills', label: t.nav.skills },
-    { href: '#projects', label: t.nav.projects },
-    { href: '#contact', label: t.nav.contact }
-];
+// Wordmark links to the home of the current language.
+const homePath = lang === 'en' ? '/' : '/es/';
 
-// Link to the same page in the other language.
-const switchPath = getLocalizedPath(Astro.url.pathname, lang === 'en' ? 'es' : 'en');
+// Language switch: same page in the other language.
+const otherLang = lang === 'en' ? 'es' : 'en';
+const switchPath = getLocalizedPath(Astro.url.pathname, otherLang);
 ---
 
 <!DOCTYPE html>
@@ -43,18 +38,22 @@ const switchPath = getLocalizedPath(Astro.url.pathname, lang === 'en' ? 'es' : '
   <body>
     <header>
       <nav class="site-nav">
-        <div class="nav-sections">
-          {sectionLinks.map((link) => (
-            <a href={link.href}>{link.label}</a>
-          ))}
-        </div>
+        <a class="wordmark" href={homePath}>{PERSON.name}</a>
         <div class="nav-meta">
           {SOCIAL_LINKS.map((link) => (
             <a href={link.url} target="_blank" rel="noopener noreferrer me">
               {link.title}
             </a>
           ))}
-          <a class="lang-switch" href={switchPath}>{t.switchToLabel}</a>
+          <a
+            class="lang-switch"
+            href={switchPath}
+            lang={otherLang}
+            hreflang={LOCALE_TAGS[otherLang]}
+            aria-label={`Switch language to ${t.switchToLabel}`}
+          >
+            {t.switchToLabel}
+          </a>
         </div>
       </nav>
     </header>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,20 +1,66 @@
 /*
-  The CSS in this style tag is based off of Bear Blog's default CSS.
-  https://github.com/HermanMartinus/bearblog/blob/297026a877bc2ab2b3bdfbd6b9f7961c350917dd/templates/styles/blog/default.css
-  License MIT: https://github.com/HermanMartinus/bearblog/blob/master/LICENSE.md
+  Global styles. Mobile-first: base rules target small screens; min-width media
+  queries scale up. Lightweight and framework-free (system fonts, no JS).
+  Color base + code/blockquote defaults originally inspired by Bear Blog (MIT).
  */
+
+/* ------------------------------------------------------------------ *
+ * Design tokens
+ * ------------------------------------------------------------------ */
+:root {
+	--bg: #fcfcfd;
+	--surface: #f4f4f6;
+	--text: #374151;
+	--text-soft: #6b7280;
+	--heading: #111827;
+	--accent: #2563eb;
+	--accent-ink: #1d4ed8;
+	--border: #e5e7eb;
+	--hero-glow: rgba(37, 99, 235, 0.06);
+
+	--font-sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial,
+		sans-serif;
+	--maxw: 50rem;
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		--bg: #0d1117;
+		--surface: #161b22;
+		--text: #c9d1d9;
+		--text-soft: #8b949e;
+		--heading: #f0f6fc;
+		--accent: #58a6ff;
+		--accent-ink: #79c0ff;
+		--border: #30363d;
+		--hero-glow: rgba(88, 166, 255, 0.08);
+	}
+}
+
+/* ------------------------------------------------------------------ *
+ * Base
+ * ------------------------------------------------------------------ */
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+}
+
 body {
-	font-family: Verdana, sans-serif;
+	font-family: var(--font-sans);
 	margin: auto;
-	padding: 20px;
-	max-width: 65ch;
+	padding: 18px;
+	max-width: var(--maxw);
 	text-align: left;
-	background-color: #fff;
+	background-color: var(--bg);
+	color: var(--text);
+	font-size: 1.0625rem;
+	line-height: 1.6;
 	word-wrap: break-word;
 	overflow-wrap: break-word;
-	line-height: 1.5;
-	color: #444;
+	-webkit-font-smoothing: antialiased;
 }
+
 h1,
 h2,
 h3,
@@ -23,69 +69,69 @@ h5,
 h6,
 strong,
 b {
-	color: #222;
+	color: var(--heading);
 }
+
 a {
-	color: #3273dc;
+	color: var(--accent);
 }
-nav a {
-	margin-right: 10px;
+
+a:hover {
+	color: var(--accent-ink);
 }
-textarea {
-	width: 100%;
-	font-size: 16px;
-}
-input {
-	font-size: 16px;
-}
-content {
-	line-height: 1.6;
-}
-table {
-	width: 100%;
-}
+
 img {
 	max-width: 100%;
 	height: auto;
 }
+
 code {
 	padding: 2px 5px;
-	background-color: #f2f2f2;
+	background-color: var(--surface);
+	border-radius: 4px;
 }
+
 pre {
 	padding: 1rem;
 }
+
 pre > code {
 	all: unset;
 }
+
 blockquote {
-	border: 1px solid #999;
-	color: #222;
-	padding: 2px 0px 2px 20px;
-	margin: 0px;
+	border-left: 3px solid var(--border);
+	color: var(--text);
+	padding: 2px 0 2px 20px;
+	margin: 0;
 	font-style: italic;
 }
 
-/* ------------------------------------------------------------------ *
- * Layout & professional sections
- * Lightweight, framework-free styles for the portfolio sections.
- * ------------------------------------------------------------------ */
-body {
-	max-width: 50rem;
+:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 2px;
+	border-radius: 4px;
 }
 
-/* Header / navigation */
+/* ------------------------------------------------------------------ *
+ * Header / navigation
+ * ------------------------------------------------------------------ */
 .site-nav {
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;
 	align-items: center;
-	gap: 12px;
-	padding: 8px 0 24px;
-	border-bottom: 1px solid #eee;
+	gap: 12px 16px;
+	padding: 8px 0 20px;
+	border-bottom: 1px solid var(--border);
 	font-size: 0.95rem;
 }
-.nav-sections,
+.wordmark {
+	font-weight: 700;
+	color: var(--heading);
+	text-decoration: none;
+	letter-spacing: -0.01em;
+}
 .nav-meta {
 	display: flex;
 	flex-wrap: wrap;
@@ -95,124 +141,134 @@ body {
 .site-nav a {
 	text-decoration: none;
 }
-.site-nav a:hover {
+.nav-meta a:hover {
 	text-decoration: underline;
 }
 .lang-switch {
-	border: 1px solid #d4d4d4;
-	border-radius: 6px;
-	padding: 2px 10px;
+	border: 1px solid var(--border);
+	border-radius: 999px;
+	padding: 3px 12px;
 	font-weight: 600;
+	line-height: 1.6;
+}
+.lang-switch:hover {
+	border-color: var(--accent);
+	color: var(--accent);
+	text-decoration: none;
 }
 
-/* Sections */
+/* ------------------------------------------------------------------ *
+ * Sections
+ * ------------------------------------------------------------------ */
 .section {
-	margin: 56px 0;
+	margin: 48px 0;
+}
+.section + .section {
+	padding-top: 8px;
 }
 .section h2 {
 	font-size: 1.5rem;
-	margin-bottom: 16px;
+	margin-bottom: 12px;
 }
 
-/* Hero */
+/* ------------------------------------------------------------------ *
+ * Hero
+ * ------------------------------------------------------------------ */
 .hero {
-	padding: 40px 0 8px;
+	display: flex;
+	align-items: center;
+	min-height: clamp(70svh, 80vh, 640px);
+	padding: 32px 0 8px;
+	background: radial-gradient(
+		120% 80% at 0% 0%,
+		var(--hero-glow),
+		transparent 60%
+	);
+}
+.hero-inner {
+	width: 100%;
 }
 .hero-role {
 	text-transform: uppercase;
-	letter-spacing: 0.08em;
-	font-size: 0.8rem;
-	color: #3273dc;
-	margin: 0 0 4px;
+	letter-spacing: 0.1em;
+	font-size: 0.78rem;
+	color: var(--accent);
+	margin: 0 0 8px;
 	font-weight: 700;
 }
 .hero-name {
-	font-size: 2.4rem;
-	line-height: 1.1;
-	margin: 0 0 12px;
+	font-size: clamp(2.5rem, 9vw, 3.75rem);
+	line-height: 1.05;
+	letter-spacing: -0.02em;
+	font-weight: 700;
+	margin: 0 0 14px;
 }
 .hero-tagline {
-	font-size: 1.15rem;
-	color: #555;
-	max-width: 40ch;
+	font-size: 1.2rem;
+	color: var(--text-soft);
+	max-width: 34ch;
+	margin: 0;
 }
 .hero-cta {
-	margin-top: 20px;
-	display: flex;
-	flex-wrap: wrap;
-	gap: 12px;
+	margin-top: 24px;
 }
 
-/* Buttons */
+/* ------------------------------------------------------------------ *
+ * Buttons
+ * ------------------------------------------------------------------ */
 .btn {
 	display: inline-block;
-	padding: 9px 18px;
+	padding: 12px 22px;
+	min-height: 44px;
 	border-radius: 8px;
 	text-decoration: none;
 	font-weight: 600;
-	border: 1px solid #3273dc;
+	border: 1px solid var(--accent);
+	transition: background-color 0.15s ease, transform 0.05s ease;
 }
 .btn-primary {
-	background-color: #3273dc;
+	background-color: var(--accent);
+	color: #fff;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+.btn-primary:hover {
+	background-color: var(--accent-ink);
+	border-color: var(--accent-ink);
 	color: #fff;
 }
-.btn-secondary {
-	color: #3273dc;
-	background-color: transparent;
-}
-.btn:hover {
-	opacity: 0.88;
+.btn-primary:active {
+	transform: translateY(1px);
 }
 
-/* Experience timeline */
-.timeline {
-	list-style: none;
-	padding: 0;
-	margin: 0;
-}
-.timeline-item {
-	padding: 0 0 24px 20px;
-	border-left: 2px solid #eaeaea;
-	position: relative;
-}
-.timeline-item::before {
-	content: "";
-	position: absolute;
-	left: -6px;
-	top: 6px;
-	width: 10px;
-	height: 10px;
-	border-radius: 50%;
-	background-color: #3273dc;
-}
-.timeline-head {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 8px;
-	align-items: baseline;
-}
-.timeline-company {
-	color: #3273dc;
-	font-weight: 600;
-}
-.timeline-meta {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 12px;
-	color: #777;
-	font-size: 0.85rem;
-	margin: 2px 0 8px;
-}
-
-/* Skills */
-.skills-grid {
+/* ------------------------------------------------------------------ *
+ * Projects (hidden for now — kept for when the section is re-enabled)
+ * ------------------------------------------------------------------ */
+.projects-grid {
 	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-	gap: 20px;
+	grid-template-columns: 1fr;
+	gap: 16px;
 }
-.skill-group h3 {
-	font-size: 1rem;
-	margin: 0 0 10px;
+.project-card {
+	display: block;
+	border: 1px solid var(--border);
+	border-radius: 10px;
+	padding: 18px;
+	text-decoration: none;
+	color: inherit;
+	transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.project-card:hover {
+	border-color: var(--accent);
+	box-shadow: 0 4px 14px rgba(0, 0, 0, 0.06);
+}
+.project-card h3 {
+	margin: 0 0 8px;
+	color: var(--accent);
+}
+.project-card p {
+	margin: 0 0 12px;
+	color: var(--text-soft);
+	font-size: 0.95rem;
 }
 .tag-list {
 	list-style: none;
@@ -223,44 +279,40 @@ body {
 	gap: 8px;
 }
 .tag {
-	background-color: #f2f2f2;
+	background-color: var(--surface);
 	border-radius: 6px;
 	padding: 3px 10px;
 	font-size: 0.85rem;
-	color: #333;
+	color: var(--text);
 }
 
-/* Projects */
-.projects-grid {
-	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-	gap: 18px;
-}
-.project-card {
-	display: block;
-	border: 1px solid #e6e6e6;
-	border-radius: 10px;
-	padding: 18px;
-	text-decoration: none;
-	color: inherit;
-	transition: border-color 0.15s ease, box-shadow 0.15s ease;
-}
-.project-card:hover {
-	border-color: #3273dc;
-	box-shadow: 0 4px 14px rgba(0, 0, 0, 0.06);
-}
-.project-card h3 {
-	margin: 0 0 8px;
-	color: #3273dc;
-}
-.project-card p {
-	margin: 0 0 12px;
-	color: #555;
-	font-size: 0.95rem;
+/* ------------------------------------------------------------------ *
+ * Scale up (tablet / desktop)
+ * ------------------------------------------------------------------ */
+@media (min-width: 640px) {
+	body {
+		padding: 20px;
+	}
+	.hero-tagline {
+		font-size: 1.25rem;
+	}
+	.section {
+		margin: 64px 0;
+	}
+	.projects-grid {
+		grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+	}
 }
 
-@media (max-width: 480px) {
-	.hero-name {
-		font-size: 2rem;
+/* ------------------------------------------------------------------ *
+ * Reduced motion
+ * ------------------------------------------------------------------ */
+@media (prefers-reduced-motion: reduce) {
+	*,
+	*::before,
+	*::after {
+		transition: none !important;
+		animation: none !important;
+		scroll-behavior: auto !important;
 	}
 }


### PR DESCRIPTION
## Resumen

Reenfoca la landing como una **introducción personal** (no un CV) y aplica un **lavado de cara UX** (con feedback de un diseñador senior), manteniendo intacto el SEO previo. Bilingüe EN/ES.

## Contenido (recruiter)
- Hero + About reescritos como intro personal: 8+ años, **sistemas altamente concurrentes y event-driven**, gusto por **construir y aprender nuevos lenguajes**; los pagos se mencionan solo como parte de la trayectoria.
- Sin métricas estilo CV ni lenguaje de búsqueda de empleo/reubicación.
- Rol elevado a **Senior Software Engineer** (copy, meta y JSON-LD `Person`).

## Estructura
- Eliminadas las secciones **Experience** y **Tech stack**.
- **Featured projects** oculto por ahora (datos y estilos conservados; markup comentado para reactivar en un paso).
- Página final: **Hero + About + Contacto**.

## UX / Diseño (mobile-first)
- **Mobile-first**: estilos base para móvil, escalado con `min-width`; verificable a ~360px.
- Tipografía **system-ui** + escala fluida (`clamp`).
- **Variables CSS + dark mode** vía `prefers-color-scheme` (sin JS) + `<meta name="color-scheme">`.
- Acento accesible **#2563eb** (corrige el contraste AA que fallaba con `#3273dc`).
- Hero protagonista, CTA pulido, `:focus-visible` y `prefers-reduced-motion`.
- Nav simplificada: **wordmark + social + pill de idioma** (con `lang`/`hreflang`/`aria-label`).
- Footer alineado a la izquierda y atenuado; eliminado CSS/markup muerto.

## Verificación
- `npm run build` limpio.
- Output: solo `#about` y `#contact` (sin experience/skills/projects); `jobTitle: "Senior Software Engineer"`; `color-scheme` presente; hreflang/OG/Twitter/JSON-LD intactos; nav con wordmark + pill `lang/hreflang`.
- Pendiente de revisión visual con `npm run dev` (no había navegador headless en el entorno para capturas).

## Notas
- Rama independiente del fix de deploy (PR #22).
- Los `TODO:` de `projects` quedan para cuando se reactive la sección.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAWLwfV1853QjEUjb9ocDf)_