### PR TITLE
Personal-intro landing + UX refresh + hero whitespace fix

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -161,7 +161,7 @@ blockquote {
  * Sections
  * ------------------------------------------------------------------ */
 .section {
-	margin: 48px 0;
+	margin: 36px 0;
 }
 .section + .section {
 	padding-top: 8px;
@@ -175,10 +175,9 @@ blockquote {
  * Hero
  * ------------------------------------------------------------------ */
 .hero {
-	display: flex;
-	align-items: center;
-	min-height: clamp(70svh, 80vh, 640px);
-	padding: 32px 0 8px;
+	/* Mobile-first: size to content so it starts right under the nav.
+	   A tall, vertically-centered hero is reintroduced only on wider screens. */
+	padding: 24px 0 8px;
 	background: radial-gradient(
 		120% 80% at 0% 0%,
 		var(--hero-glow),
@@ -301,6 +300,17 @@ blockquote {
 	}
 	.projects-grid {
 		grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+	}
+}
+
+@media (min-width: 768px) {
+	/* Give the hero presence on larger screens — modest height, not full-viewport,
+	   so the short page doesn't develop big empty gaps. */
+	.hero {
+		display: flex;
+		align-items: center;
+		min-height: 56vh;
+		padding: 40px 0 16px;
 	}
 }
 


### PR DESCRIPTION
## Resumen

PR contra `main` que reúne el rediseño de la landing y el arreglo de espaciado del hero. **Supersede a la #23**: como esta rama está apilada sobre la de #23, al apuntar a `main` el diff incluye todo el conjunto de cambios.

### 1) Reenfoque de contenido + UX (antes en #23)
- Hero + About como **introducción personal** (8+ años, sistemas altamente concurrentes y event-driven, gusto por construir y aprender nuevos lenguajes; pagos solo como parte de la trayectoria). Sin métricas de CV ni lenguaje de búsqueda de empleo/reubicación.
- Rol **Senior Software Engineer** (copy, meta, JSON-LD).
- Eliminadas *Experience* y *Tech stack*; *Featured projects* oculto (conservado, comentado).
- UX mobile-first: tipografía system-ui + escala fluida, variables CSS + **dark mode** (`prefers-color-scheme`), acento accesible `#2563eb`, CTA pulido, `:focus-visible`, `prefers-reduced-motion`, `color-scheme` meta.
- Nav simplificada (wordmark + social + pill de idioma con `lang`/`hreflang`/`aria-label`); footer atenuado.

### 2) Arreglo de espacio en blanco del hero
- El hero forzaba `min-height ~80vh` centrado verticalmente → vacíos en móvil.
- Móvil: el hero toma la altura de su contenido (arranca bajo la nav).
- Desktop (≥768px): hero con presencia moderada (`56vh`), sin pantalla completa.
- Ritmo vertical en móvil más compacto.

## Verificación

- `npm run build` limpio.
- HTML: solo `#about` y `#contact`; `jobTitle: "Senior Software Engineer"`; hreflang/OG/Twitter/JSON-LD y `color-scheme` presentes.
- Revisión visual recomendada con `npm run dev` a ~360px y alternando tema claro/oscuro.

## Nota

Al superseder a la #23, esa PR puede cerrarse si se mergea esta. (Independiente del fix de deploy, PR #22.)

https://claude.ai/code/session_01CAWLwfV1853QjEUjb9ocDf