### PR TITLE
Make hero content-driven on all screens (fix desktop whitespace)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -175,8 +175,10 @@ blockquote {
  * Hero
  * ------------------------------------------------------------------ */
 .hero {
-	/* Mobile-first: size to content so it starts right under the nav.
-	   A tall, vertically-centered hero is reintroduced only on wider screens. */
+	/* Mobile-first and content-driven: the hero sizes to its content at every
+	   breakpoint (no viewport-based min-height, no vertical centering), so it
+	   never reserves empty space. Larger screens just get more breathing room
+	   via padding. */
 	padding: 24px 0 8px;
 	background: radial-gradient(
 		120% 80% at 0% 0%,
@@ -304,13 +306,10 @@ blockquote {
 }
 
 @media (min-width: 768px) {
-	/* Give the hero presence on larger screens — modest height, not full-viewport,
-	   so the short page doesn't develop big empty gaps. */
+	/* More breathing room on larger screens — via padding only, never a
+	   viewport-height box, so no empty gap forms before the next section. */
 	.hero {
-		display: flex;
-		align-items: center;
-		min-height: 56vh;
-		padding: 40px 0 16px;
+		padding: 56px 0 16px;
 	}
 }
 


### PR DESCRIPTION
## Problema

Tras el fix móvil (#26, ya en `main`), en **escritorio** seguía habiendo espacio en blanco: un hueco vacío entre el hero y "About me".

## Causa

El bloque `@media (min-width: 768px)` aún reservaba `min-height: 56vh` y **centraba el hero verticalmente** (`align-items: center`). Con contenido corto, la parte inferior de esa caja de 56vh quedaba vacía → hueco antes de la siguiente sección. Misma causa raíz que en móvil, pero en pantallas grandes.

## Solución (solo CSS, mobile-first + responsive)

- El hero se **dimensiona por su contenido en todos los breakpoints**: se elimina el `min-height` basado en viewport y el centrado vertical.
- En pantallas grandes solo se aumenta el **padding** (`24px` móvil → `56px` arriba en ≥768px) para dar aire, sin reservar altura.
- Resultado: **sin espacio vacío en ninguna pantalla**, manteniéndolo mobile-first y totalmente responsive.

Diff acotado a un único archivo (`src/styles/global.css`).

## Verificación

- `npm run build` limpio; en el CSS ya no queda ningún `min-height`/`vh`/`align-items:center` asociado al hero.
- Revisar con `npm run dev` redimensionando de móvil estrecho a desktop ancho: el hero arranca bajo la nav y "About me" aparece a distancia natural en todos los tamaños.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAWLwfV1853QjEUjb9ocDf)_