### PR TITLE
Remove hero CTA button + drop "Senior" from title

### DIFF
--- a/src/components/HomeContent.astro
+++ b/src/components/HomeContent.astro
@@ -12,17 +12,9 @@ const t = getContent(lang);
 
 <section class="hero">
     <div class="hero-inner">
-        <div class="hero-text">
-            <p class="hero-role">{t.hero.role}</p>
-            <h1 class="hero-name">{t.hero.name}</h1>
-            <p class="hero-tagline">{t.hero.tagline}</p>
-            <div class="hero-cta">
-                <a class="btn btn-primary" href="#contact">{t.hero.ctaPrimary}</a>
-            </div>
-        </div>
-        <aside class="hero-accent" aria-hidden="true">
-            <span class="monogram">LE</span>
-        </aside>
+        <p class="hero-role">{t.hero.role}</p>
+        <h1 class="hero-name">{t.hero.name}</h1>
+        <p class="hero-tagline">{t.hero.tagline}</p>
     </div>
 </section>
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,10 +1,10 @@
-export const SITE_TITLE = 'Leonardo Esparis — Senior Software Engineer';
+export const SITE_TITLE = 'Leonardo Esparis — Software Engineer';
 export const SITE_DESCRIPTION =
-    'Leonardo Esparis, senior software engineer with 8+ years building backends — highly concurrent, event-driven, distributed systems in Python.';
+    'Leonardo Esparis, software engineer with 8+ years building backends — highly concurrent, event-driven, distributed systems in Python.';
 
 export const PERSON = {
     name: 'Leonardo Esparis',
-    jobTitle: 'Senior Software Engineer',
+    jobTitle: 'Software Engineer',
     email: 'ljesparis@gmail.com',
     linkedin: 'https://www.linkedin.com/in/leoesparis/',
     github: 'https://github.com/ljesparis/'

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -2,19 +2,18 @@ import type { SiteContent } from './types';
 
 export const en: SiteContent = {
     meta: {
-        title: 'Leonardo Esparis — Senior Software Engineer',
+        title: 'Leonardo Esparis — Software Engineer',
         description:
-            'Leonardo Esparis, senior software engineer with 8+ years building backends — highly concurrent, event-driven, distributed systems in Python.'
+            'Leonardo Esparis, software engineer with 8+ years building backends — highly concurrent, event-driven, distributed systems in Python.'
     },
 
     switchToLabel: 'Español',
 
     hero: {
         name: 'Leonardo Esparis',
-        role: 'Senior Software Engineer',
+        role: 'Software Engineer',
         tagline:
-            'I build the kind of systems that have to stay calm under pressure — and I love every part of the craft.',
-        ctaPrimary: 'Get in touch'
+            'I build the kind of systems that have to stay calm under pressure — and I love every part of the craft.'
     },
 
     about: {

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -2,19 +2,18 @@ import type { SiteContent } from './types';
 
 export const es: SiteContent = {
     meta: {
-        title: 'Leonardo Esparis — Ingeniero de Software Senior',
+        title: 'Leonardo Esparis — Ingeniero de Software',
         description:
-            'Leonardo Esparis, ingeniero de software senior con más de 8 años construyendo backends: sistemas distribuidos, altamente concurrentes y orientados a eventos en Python.'
+            'Leonardo Esparis, ingeniero de software con más de 8 años construyendo backends: sistemas distribuidos, altamente concurrentes y orientados a eventos en Python.'
     },
 
     switchToLabel: 'English',
 
     hero: {
         name: 'Leonardo Esparis',
-        role: 'Ingeniero de Software Senior',
+        role: 'Ingeniero de Software',
         tagline:
-            'Construyo sistemas que tienen que mantener la calma bajo presión, y disfruto cada parte del oficio.',
-        ctaPrimary: 'Contáctame'
+            'Construyo sistemas que tienen que mantener la calma bajo presión, y disfruto cada parte del oficio.'
     },
 
     about: {

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -15,7 +15,6 @@ export interface SiteContent {
         name: string;
         role: string;
         tagline: string;
-        ctaPrimary: string;
     };
     about: {
         heading: string;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -158,9 +158,6 @@ blockquote {
 .hero-inner {
 	width: 100%;
 }
-.hero-accent {
-	display: none;
-}
 .hero-role {
 	text-transform: uppercase;
 	letter-spacing: 0.1em;
@@ -181,9 +178,6 @@ blockquote {
 	color: var(--text-soft);
 	max-width: 34ch;
 	margin: 0;
-}
-.hero-cta {
-	margin-top: 24px;
 }
 
 .btn {


### PR DESCRIPTION
## Resumen

- **Elimina el botón "Get in touch" del hero.** Se conserva el botón **"Email me"** de la sección de contacto.
- **Quita "Senior"** del rol y de los metadatos.

Incluye además el trabajo previo (a la que **supersede** #30): hero de una sola columna, wordmark `ljesparis`, textos del About sin "zona de confort"/"Madrid", espaciado compacto y código sin comentarios.

## Cambios de esta iteración
- `HomeContent.astro`: eliminado el `<div class="hero-cta">` con el botón "Get in touch". El botón "Email me" (mailto) en Contacto se mantiene.
- Limpieza: quitado el campo `hero.ctaPrimary` (type + diccionarios EN/ES) y la regla CSS `.hero-cta`, ya sin uso.
- **Sin "Senior":** rol `Software Engineer` / `Ingeniero de Software`; títulos, `meta` y JSON-LD `jobTitle` actualizados en EN y ES.

## Verificación
- `npm run build` limpio.
- Sin referencias residuales a `ctaPrimary` / `hero-cta`; sin ninguna aparición de "senior" en `src/`.
- Output: `hero-role` = "Software Engineer", `jobTitle` = "Software Engineer"; el botón "Email me" sigue presente.

https://claude.ai/code/session_01CAWLwfV1853QjEUjb9ocDf

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAWLwfV1853QjEUjb9ocDf)_