### PR TITLE
Language switch globe icon + remove Contact section

### DIFF
--- a/src/components/HomeContent.astro
+++ b/src/components/HomeContent.astro
@@ -1,6 +1,5 @@
 ---
 import { getContent, type Lang } from '../i18n/utils';
-import { PERSON } from '../consts';
 
 export interface Props {
     lang: Lang;
@@ -21,14 +20,4 @@ const t = getContent(lang);
 <section id="about" class="section">
     <h2>{t.about.heading}</h2>
     {t.about.paragraphs.map((p) => <p>{p}</p>)}
-</section>
-
-<section id="contact" class="section">
-    <h2>{t.contact.heading}</h2>
-    <p>{t.contact.text}</p>
-    <p>
-        <a class="btn btn-primary" href={`mailto:${PERSON.email}`}>
-            {t.contact.emailLabel}
-        </a>
-    </p>
 </section>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -35,11 +35,5 @@ export const en: SiteContent = {
                 url: 'https://github.com/ljesparis/'
             }
         ]
-    },
-
-    contact: {
-        heading: 'Get in touch',
-        text: "Got an interesting problem or idea? I'd be glad to hear from you.",
-        emailLabel: 'Email me'
     }
 };

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -35,11 +35,5 @@ export const es: SiteContent = {
                 url: 'https://github.com/ljesparis/'
             }
         ]
-    },
-
-    contact: {
-        heading: 'Contacto',
-        text: '¿Tienes un problema o una idea interesante? Me encantará saber de ti.',
-        emailLabel: 'Escríbeme'
     }
 };

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -24,9 +24,4 @@ export interface SiteContent {
         heading: string;
         items: ProjectItem[];
     };
-    contact: {
-        heading: string;
-        text: string;
-        emailLabel: string;
-    };
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -50,7 +50,22 @@ const switchPath = getLocalizedPath(Astro.url.pathname, otherLang);
             hreflang={LOCALE_TAGS[otherLang]}
             aria-label={`Switch language to ${t.switchToLabel}`}
           >
-            {t.switchToLabel}
+            <svg
+              class="lang-switch-globe"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <circle cx="12" cy="12" r="9" />
+              <path d="M3 12h18" />
+              <path d="M12 3a14 14 0 0 1 0 18a14 14 0 0 1 0-18" />
+            </svg>
+            <span class="lang-switch-code">{lang.toUpperCase()}</span>
           </a>
         </div>
       </nav>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -129,11 +129,22 @@ blockquote {
 	text-decoration: underline;
 }
 .lang-switch {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.35em;
 	border: 1px solid var(--border);
 	border-radius: 999px;
 	padding: 3px 12px;
 	font-weight: 600;
 	line-height: 1.6;
+}
+.lang-switch-globe {
+	width: 1.05em;
+	height: 1.05em;
+	flex-shrink: 0;
+}
+.lang-switch-code {
+	letter-spacing: 0.02em;
 }
 .lang-switch:hover {
 	border-color: var(--accent);
@@ -178,30 +189,6 @@ blockquote {
 	color: var(--text-soft);
 	max-width: 34ch;
 	margin: 0;
-}
-
-.btn {
-	display: inline-block;
-	padding: 12px 22px;
-	min-height: 44px;
-	border-radius: 8px;
-	text-decoration: none;
-	font-weight: 600;
-	border: 1px solid var(--accent);
-	transition: background-color 0.15s ease, transform 0.05s ease;
-}
-.btn-primary {
-	background-color: var(--accent);
-	color: #fff;
-	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
-}
-.btn-primary:hover {
-	background-color: var(--accent-ink);
-	border-color: var(--accent-ink);
-	color: #fff;
-}
-.btn-primary:active {
-	transform: translateY(1px);
 }
 
 .projects-grid {


### PR DESCRIPTION
## Resumen

- **Selector de idioma con icono de globo + código del idioma actual** (estilo "🌐 EN", como el screenshot de Fever).
- **Eliminada la sección de Contacto** (ya están LinkedIn y GitHub en la nav).

## Cambios

### Selector de idioma
- En vez del texto "Español/English", la pastilla muestra un **globo SVG inline pequeño + el código del idioma actual**: `EN` en inglés, `ES` en español.
- Al pulsarlo sigue navegando al **otro idioma** (con `hreflang` y `aria-label` accesible que indica que cambia de idioma).
- El globo es SVG inline con `currentColor` (hereda color y funciona en claro/oscuro) y está dimensionado en `em` (~1.05em) → **proporcional al texto**, no grande.

### Contacto
- Eliminada por completo la sección de Contacto (encabezado + texto + botón "Email me").
- Limpieza sin código muerto: quitadas las entradas `contact` de los diccionarios (EN/ES) y del tipo `SiteContent`, el import `PERSON` (ya sin uso) en `HomeContent.astro` y las reglas CSS `.btn`/`.btn-primary`.
- `PERSON` se conserva en `consts.ts` (lo usan `SOCIAL_LINKS` y el JSON-LD de `BaseHead`).

La página queda como **Hero + About** (presentación), con LinkedIn/GitHub y el selector de idioma en la nav.

## Verificación
- `npm run build` limpio; sin referencias residuales a `contact` / `.btn` / `PERSON` en `HomeContent`.
- HTML generado: nav muestra `🌐 EN` en `/` y `🌐 ES` en `/es/`; sin sección de contacto.

## Decisión de diseño (por si quieres ajustarla)
El botón muestra el **idioma actual** (como el screenshot). Si prefieres que muestre el idioma de **destino** (p. ej. estando en inglés ver "ES"), lo cambio en un momento.

https://claude.ai/code/session_01CAWLwfV1853QjEUjb9ocDf

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAWLwfV1853QjEUjb9ocDf)_