### PR TITLE
Hero tagline + homepage trimmed to Hero/About only

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,5 +1,13 @@
 ---
 import { PERSON } from '../consts';
+import { getLangFromUrl, getContent, type Lang } from '../i18n/utils';
+
+export interface Props {
+    lang: Lang;
+}
+
+const { lang } = Astro.props;
+const t = getContent(lang);
 const [firstName, ...rest] = PERSON.name.split(' ');
 const lastName = rest.join(' ');
 ---
@@ -9,6 +17,8 @@ const lastName = rest.join(' ');
         $ whoami<span class="cursor" aria-hidden="true"></span>
     </p>
     <h1 class="name">{firstName}<br />{lastName}</h1>
+    <p class="role">{PERSON.jobTitle}</p>
+    <p class="tagline">&gt; {t.hero.tagline}</p>
 </header>
 
 <style>
@@ -23,7 +33,7 @@ const lastName = rest.join(' ');
         font-size: 0.8125rem;
         color: var(--accent);
         letter-spacing: 0.05em;
-        margin-bottom: 18px;
+        margin-bottom: 20px;
         text-shadow: 0 0 6px rgba(63, 224, 143, 0.4);
     }
     .cursor {
@@ -44,5 +54,20 @@ const lastName = rest.join(' ');
         letter-spacing: -0.02em;
         color: var(--heading);
         text-shadow: 0 0 20px rgba(63, 224, 143, 0.35);
+        margin-bottom: 18px;
+    }
+    .role {
+        font-family: var(--font-mono);
+        font-size: 0.9375rem;
+        font-weight: 500;
+        color: var(--accent-bright);
+        letter-spacing: 0.03em;
+        margin-bottom: 10px;
+    }
+    .tagline {
+        font-family: var(--font-mono);
+        font-size: 0.875rem;
+        color: var(--text-muted);
+        letter-spacing: 0.01em;
     }
 </style>

--- a/src/components/HomeContent.astro
+++ b/src/components/HomeContent.astro
@@ -10,17 +10,5 @@ export interface Props {
 const { lang } = Astro.props;
 ---
 
-<Hero />
+<Hero lang={lang} />
 <About lang={lang} />
-
-{/*
-    Projects and Writing are ready to enable when there is real content to ship.
-    Uncomment the imports above and the blocks below; data lives in
-    src/i18n/{en,es}.ts under `projects` and `writing`.
-
-    import Projects from './Projects.astro';
-    import Writing from './Writing.astro';
-
-    <Projects lang={lang} />
-    <Writing lang={lang} />
-*/}

--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -17,12 +17,16 @@ const t = getContent(lang);
                 <a class="card" href={project.href}>
                     <div class="head">
                         <span class="name">{project.name}</span>
-                        <span class="arrow" aria-hidden="true">
-                            →
-                        </span>
+                        <svg class="arrow" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M7 17L17 7M17 7H7M17 7v10" />
+                        </svg>
                     </div>
                     <p class="desc">{project.description}</p>
-                    <div class="tags">{project.tags.join(' · ')}</div>
+                    <div class="tags">
+                        {project.tags.map((tag) => (
+                            <span class="tag">{tag}</span>
+                        ))}
+                    </div>
                 </a>
             ))
         }
@@ -32,7 +36,7 @@ const t = getContent(lang);
 <style>
     .projects {
         margin-bottom: 40px;
-        animation: revealUp 0.6s ease 0.24s both;
+        animation: revealUp 0.6s ease 0.32s both;
     }
     .label {
         font-family: var(--font-mono);
@@ -46,46 +50,63 @@ const t = getContent(lang);
     .list {
         display: flex;
         flex-direction: column;
-        gap: 12px;
+        gap: 10px;
     }
     .card {
         display: block;
-        padding: 18px;
+        padding: 20px;
         border-radius: var(--radius);
         background: var(--surface-item);
         border: 1px solid var(--border-item);
         text-decoration: none;
-        transition: border-color 0.2s ease, background 0.2s ease;
+        cursor: pointer;
+        transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
     }
     .card:hover {
         border-color: var(--border-item-hover);
         background: var(--surface-item-hover);
+        transform: translateY(-1px);
     }
     .head {
         display: flex;
         justify-content: space-between;
-        align-items: baseline;
-        margin-bottom: 7px;
+        align-items: center;
+        margin-bottom: 8px;
     }
     .name {
-        font-size: 1.125rem;
+        font-size: 1.0625rem;
         font-weight: 600;
         color: var(--heading-strong);
     }
     .arrow {
-        font-family: var(--font-mono);
-        font-size: 0.75rem;
         color: var(--accent);
+        opacity: 0.6;
+        flex-shrink: 0;
+        transition: opacity 0.2s ease, transform 0.2s ease;
+    }
+    .card:hover .arrow {
+        opacity: 1;
+        transform: translate(2px, -2px);
     }
     .desc {
         font-size: 0.875rem;
         line-height: 1.55;
         color: var(--text-muted);
-        margin-bottom: 11px;
+        margin-bottom: 14px;
     }
     .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+    }
+    .tag {
         font-family: var(--font-mono);
-        font-size: 0.75rem;
+        font-size: 0.6875rem;
         color: var(--mono-muted);
+        background: rgba(63, 224, 143, 0.06);
+        border: 1px solid rgba(63, 224, 143, 0.12);
+        border-radius: 4px;
+        padding: 3px 8px;
+        letter-spacing: 0.03em;
     }
 </style>

--- a/src/components/Writing.astro
+++ b/src/components/Writing.astro
@@ -26,7 +26,7 @@ const t = getContent(lang);
 <style>
     .writing {
         margin-bottom: 44px;
-        animation: revealUp 0.6s ease 0.32s both;
+        animation: revealUp 0.6s ease 0.4s both;
     }
     .label {
         font-family: var(--font-mono);

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -9,6 +9,10 @@ export const en: SiteContent = {
 
     switchToLabel: 'Español',
 
+    hero: {
+        tagline: 'writing code, building things, figuring out the rest'
+    },
+
     about: {
         body: "For the last 4 years I've been focused on improving the payment experience for hundreds of users, building high-concurrency, event-driven systems made to stay reliable and predictable, even under heavy load. Most of my code lives in Python and Django, leaning on hexagonal architecture and DDD to keep things clean — and off the clock you'll find me deep in side projects, picking up new languages just for the fun of it."
     },

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -9,6 +9,10 @@ export const es: SiteContent = {
 
     switchToLabel: 'English',
 
+    hero: {
+        tagline: 'escribiendo código, construyendo cosas, resolviendo lo demás'
+    },
+
     about: {
         body: 'Durante los últimos 4 años me he centrado en mejorar la experiencia de pago de cientos de usuarios, construyendo sistemas de alta concurrencia y orientados a eventos, pensados para mantenerse fiables y predecibles incluso bajo mucha carga. La mayor parte de mi código vive en Python y Django, apoyándome en arquitectura hexagonal y DDD para mantenerlo limpio — y fuera del trabajo me encontrarás metido en proyectos personales, aprendiendo nuevos lenguajes solo por diversión.'
     },

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -17,6 +17,9 @@ export interface SiteContent {
         description: string;
     };
     switchToLabel: string;
+    hero: {
+        tagline: string;
+    };
     about: {
         body: string;
     };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -30,8 +30,8 @@
 	--font-mono: "JetBrains Mono Variable", ui-monospace, "SFMono-Regular", Menlo,
 		monospace;
 
-	--container: 640px;
-	--gutter: clamp(1rem, 4vw, 1.375rem);
+	--container: 700px;
+	--gutter: clamp(1rem, 4vw, 1.5rem);
 
 	--radius-sm: 6px;
 	--radius: 12px;


### PR DESCRIPTION
- Add role and tagline to Hero; tagline is generic (building/crafting, not job-specific)
- Wire lang prop through Hero for i18n tagline
- Remove Stack component and all references; remove stack from i18n types
- Hide Projects and Writing sections until real content is ready
- Polish Projects card (pill tags, SVG arrow with hover animation, lift on hover)
- Widen container to 700px