### PR TITLE
add blog post on post-mortems (EN + ES)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 
-
 # environment variables
 .env
 .env.production

--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -10,9 +10,10 @@ const t = getContent(lang);
 ---
 
 <section class="about" data-reveal aria-labelledby="about-label">
-    <h2 class="label" id="about-label">
+    <h2 class="sr-only" id="about-label">About</h2>
+    <p class="label" aria-hidden="true">
         <span class="dot" aria-hidden="true"></span>cat about.md
-    </h2>
+    </p>
     <p class="body">{t.about.body}</p>
 </section>
 

--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -11,39 +11,31 @@ const t = getContent(lang);
 
 <section class="about" data-reveal aria-labelledby="about-label">
     <h2 class="sr-only" id="about-label">About</h2>
-    <p class="label" aria-hidden="true">
-        <span class="dot" aria-hidden="true"></span>cat about.md
-    </p>
-    <p class="body">{t.about.body}</p>
+    <p class="label" aria-hidden="true">$ cat about.md</p>
+    <div class="card">
+        <p class="body">{t.about.body}</p>
+    </div>
 </section>
 
 <style>
     .about {
-        padding: clamp(18px, 5vw, 24px);
         margin-bottom: 40px;
-        border-radius: var(--radius-lg);
-        background: var(--surface-card);
-        border: 1px solid var(--border-card);
         animation: revealUp 0.6s ease 0.16s both;
     }
     .label {
-        display: flex;
-        align-items: center;
-        gap: 8px;
         font-family: var(--font-mono);
-        font-size: 0.75rem;
+        font-size: 0.875rem;
         font-weight: 400;
-        color: var(--mono-muted);
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
+        color: var(--accent);
+        letter-spacing: 0.06em;
+        text-shadow: 0 0 6px rgba(63, 224, 143, 0.3);
         margin-bottom: 16px;
     }
-    .dot {
-        width: 7px;
-        height: 7px;
-        border-radius: 50%;
-        background: var(--accent);
-        box-shadow: 0 0 8px var(--accent);
+    .card {
+        padding: clamp(18px, 5vw, 24px);
+        border-radius: var(--radius-lg);
+        background: var(--surface-card);
+        border: 1px solid var(--border-card);
     }
     .body {
         font-size: 1rem;

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -61,7 +61,6 @@ const personSchema = {
 <meta name="author" content={PERSON.name} />
 <link rel="icon" type="image/x-icon" href="/favicon.ico" />
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-<meta name="generator" content={Astro.generator} />
 
 <link rel="canonical" href={canonicalURL} />
 

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -58,6 +58,7 @@ const personSchema = {
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <meta name="color-scheme" content="dark" />
 <meta name="theme-color" content="#04070a" />
+<meta name="robots" content="index, follow" />
 <meta name="author" content={PERSON.name} />
 <link rel="icon" type="image/x-icon" href="/favicon.ico" />
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
@@ -98,7 +99,6 @@ const personSchema = {
 {PERSON.twitter && <meta name="twitter:site" content={`@${PERSON.twitter}`} />}
 {PERSON.twitter && <meta name="twitter:creator" content={`@${PERSON.twitter}`} />}
 
-<script
-    type="application/ld+json"
-    set:html={JSON.stringify(personSchema)}
-/>
+{ogType !== 'article' && (
+    <script type="application/ld+json" set:html={JSON.stringify(personSchema)} />
+)}

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -17,9 +17,10 @@ export interface Props {
     description: string;
     lang: Lang;
     image?: string;
+    ogType?: string;
 }
 
-const { title, description, lang, image = SOCIAL_IMAGE } = Astro.props;
+const { title, description, lang, image = SOCIAL_IMAGE, ogType = 'website' } = Astro.props;
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const imageURL = new URL(image, Astro.site);
@@ -74,7 +75,7 @@ const personSchema = {
 <meta name="title" content={title} />
 <meta name="description" content={description} />
 
-<meta property="og:type" content="website" />
+<meta property="og:type" content={ogType} />
 <meta property="og:site_name" content={PERSON.name} />
 <meta property="og:url" content={canonicalURL} />
 <meta property="og:title" content={title} />

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -16,7 +16,7 @@ const lastName = rest.join(' ');
     <p class="whoami">
         $ whoami<span class="cursor" aria-hidden="true"></span>
     </p>
-    <h1 class="name">{firstName}<br />{lastName}</h1>
+    <h1 class="name">{firstName}<br />{lastName}<span class="sr-only">, {PERSON.jobTitle}</span></h1>
     <p class="role">{PERSON.jobTitle}</p>
     <p class="tagline">&gt; {t.hero.tagline}</p>
 </header>

--- a/src/components/HomeContent.astro
+++ b/src/components/HomeContent.astro
@@ -1,6 +1,7 @@
 ---
 import Hero from './Hero.astro';
 import About from './About.astro';
+import Writing from './Writing.astro';
 import type { Lang } from '../i18n/utils';
 
 export interface Props {
@@ -12,3 +13,4 @@ const { lang } = Astro.props;
 
 <Hero lang={lang} />
 <About lang={lang} />
+<Writing lang={lang} />

--- a/src/components/Writing.astro
+++ b/src/components/Writing.astro
@@ -10,7 +10,8 @@ const t = getContent(lang);
 ---
 
 <section class="writing" data-reveal aria-labelledby="writing-label">
-    <h2 class="label" id="writing-label">$ cat ./writing</h2>
+    <h2 class="sr-only" id="writing-label">Writing</h2>
+    <p class="label" aria-hidden="true">$ cat ./writing</p>
     <div class="list">
         {
             t.writing.items.map((post) => (

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -39,19 +39,9 @@ export const en: SiteContent = {
     writing: {
         items: [
             {
-                title: 'Keeping distributed services coherent',
-                date: '03·26',
-                href: '#'
-            },
-            {
-                title: 'Why hexagonal architecture feels like home',
-                date: '01·26',
-                href: '#'
-            },
-            {
-                title: 'Idempotency in payment systems',
-                date: '11·25',
-                href: '#'
+                title: 'Post-mortems are awesome (and here\'s why you should love them too)',
+                date: '06·26',
+                href: '/blog/post-mortems-are-awesome'
             }
         ]
     },

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -39,19 +39,9 @@ export const es: SiteContent = {
     writing: {
         items: [
             {
-                title: 'Mantener coherentes los servicios distribuidos',
-                date: '03·26',
-                href: '#'
-            },
-            {
-                title: 'Por qué la arquitectura hexagonal se siente como en casa',
-                date: '01·26',
-                href: '#'
-            },
-            {
-                title: 'Idempotencia en sistemas de pago',
-                date: '11·25',
-                href: '#'
+                title: 'Los post-mortems son geniales (y aquí te cuento por qué deberías amarlos también)',
+                date: '06·26',
+                href: '/es/blog/post-mortems-are-awesome'
             }
         ]
     },

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -4,6 +4,7 @@ import SiteNav from '../components/SiteNav.astro';
 import Footer from '../components/Footer.astro';
 import GoogleAnalytics from '../components/GoogleAnalytics.astro';
 import { getLangFromUrl, LOCALE_TAGS } from '../i18n/utils';
+import { PERSON } from '../consts';
 
 export interface Props {
     title: string;
@@ -65,6 +66,16 @@ const blogPostingSchema = {
                         </header>
                         <div class="post-body">
                             <slot />
+                        </div>
+                        <div class="post-author">
+                            <div class="author-info">
+                                <span class="author-name">{PERSON.name}</span>
+                                <span class="author-role">{PERSON.jobTitle}</span>
+                            </div>
+                            <div class="author-links">
+                                <a href={PERSON.linkedin} rel="noopener noreferrer me" target="_blank">LinkedIn</a>
+                                <a href={PERSON.github} rel="noopener noreferrer me" target="_blank">GitHub</a>
+                            </div>
                         </div>
                     </article>
                 </main>
@@ -272,6 +283,53 @@ const blogPostingSchema = {
         text-align: left;
         padding: 0.6rem 0.75rem;
         border-bottom: 1px solid var(--border);
+    }
+
+    .post-author {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 16px;
+        margin-top: 3rem;
+        padding-top: 1.5rem;
+        border-top: 1px solid var(--divider);
+    }
+
+    .author-info {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+    }
+
+    .author-name {
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--text-soft);
+    }
+
+    .author-role {
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        color: var(--text-muted);
+        letter-spacing: 0.04em;
+    }
+
+    .author-links {
+        display: flex;
+        gap: 12px;
+    }
+
+    .author-links a {
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        color: var(--accent);
+        text-decoration: none;
+        letter-spacing: 0.04em;
+        transition: opacity 0.15s ease;
+    }
+
+    .author-links a:hover {
+        opacity: 0.7;
     }
 
     .post-body :global(td) {

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -4,7 +4,6 @@ import SiteNav from '../components/SiteNav.astro';
 import Footer from '../components/Footer.astro';
 import GoogleAnalytics from '../components/GoogleAnalytics.astro';
 import { getLangFromUrl, LOCALE_TAGS } from '../i18n/utils';
-import { PERSON } from '../consts';
 
 export interface Props {
     title: string;
@@ -66,16 +65,6 @@ const blogPostingSchema = {
                         </header>
                         <div class="post-body">
                             <slot />
-                        </div>
-                        <div class="post-author">
-                            <div class="author-info">
-                                <span class="author-name">{PERSON.name}</span>
-                                <span class="author-role">{PERSON.jobTitle}</span>
-                            </div>
-                            <div class="author-links">
-                                <a href={PERSON.linkedin} rel="noopener noreferrer me" target="_blank">LinkedIn</a>
-                                <a href={PERSON.github} rel="noopener noreferrer me" target="_blank">GitHub</a>
-                            </div>
                         </div>
                     </article>
                 </main>
@@ -283,53 +272,6 @@ const blogPostingSchema = {
         text-align: left;
         padding: 0.6rem 0.75rem;
         border-bottom: 1px solid var(--border);
-    }
-
-    .post-author {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        gap: 16px;
-        margin-top: 3rem;
-        padding-top: 1.5rem;
-        border-top: 1px solid var(--divider);
-    }
-
-    .author-info {
-        display: flex;
-        flex-direction: column;
-        gap: 2px;
-    }
-
-    .author-name {
-        font-size: 0.9rem;
-        font-weight: 600;
-        color: var(--text-soft);
-    }
-
-    .author-role {
-        font-family: var(--font-mono);
-        font-size: 0.75rem;
-        color: var(--text-muted);
-        letter-spacing: 0.04em;
-    }
-
-    .author-links {
-        display: flex;
-        gap: 12px;
-    }
-
-    .author-links a {
-        font-family: var(--font-mono);
-        font-size: 0.75rem;
-        color: var(--accent);
-        text-decoration: none;
-        letter-spacing: 0.04em;
-        transition: opacity 0.15s ease;
-    }
-
-    .author-links a:hover {
-        opacity: 0.7;
     }
 
     .post-body :global(td) {

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -7,14 +7,16 @@ import { getLangFromUrl, LOCALE_TAGS } from '../i18n/utils';
 
 export interface Props {
     title: string;
+    seoTitle?: string;
     description: string;
     pubDate: string | Date;
     image?: string;
 }
 
 const fm = ((Astro.props as any).frontmatter ?? Astro.props) as Props;
-const { title, description, pubDate, image } = fm;
+const { title, seoTitle, description, pubDate, image } = fm;
 const lang = getLangFromUrl(Astro.url);
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const dateObj = (() => {
     if (pubDate instanceof Date && !isNaN(pubDate.getTime())) return pubDate;
     const s = String(pubDate ?? '');
@@ -22,12 +24,26 @@ const dateObj = (() => {
     return isNaN(d.getTime()) ? new Date() : d;
 })();
 const isoDate = dateObj.toISOString().split('T')[0];
+
+const blogPostingSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: title,
+    description: description,
+    datePublished: isoDate,
+    dateModified: isoDate,
+    url: canonicalURL.href,
+    inLanguage: lang === 'en' ? 'en-US' : 'es-ES',
+    author: { '@type': 'Person', '@id': 'https://ljesparis.com/#person' },
+    publisher: { '@type': 'Person', '@id': 'https://ljesparis.com/#person' },
+};
 ---
 
 <!DOCTYPE html>
 <html lang={LOCALE_TAGS[lang]}>
     <head>
-        <BaseHead title={`${title} — Leonardo Esparis`} description={description} lang={lang} image={image} />
+        <BaseHead title={seoTitle ?? `${title} — Leonardo Esparis`} description={description} lang={lang} image={image} ogType="article" />
+        <script type="application/ld+json" set:html={JSON.stringify(blogPostingSchema)} />
     </head>
     <body>
         <div class="page">

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -12,7 +12,6 @@ export interface Props {
     image?: string;
 }
 
-// Astro v4 MDX layouts receive frontmatter as a nested `frontmatter` prop
 const fm = ((Astro.props as any).frontmatter ?? Astro.props) as Props;
 const { title, description, pubDate, image } = fm;
 const lang = getLangFromUrl(Astro.url);

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -1,0 +1,268 @@
+---
+import BaseHead from '../components/BaseHead.astro';
+import SiteNav from '../components/SiteNav.astro';
+import Footer from '../components/Footer.astro';
+import GoogleAnalytics from '../components/GoogleAnalytics.astro';
+import { getLangFromUrl, LOCALE_TAGS } from '../i18n/utils';
+
+export interface Props {
+    title: string;
+    description: string;
+    pubDate: string | Date;
+    image?: string;
+}
+
+// Astro v4 MDX layouts receive frontmatter as a nested `frontmatter` prop
+const fm = ((Astro.props as any).frontmatter ?? Astro.props) as Props;
+const { title, description, pubDate, image } = fm;
+const lang = getLangFromUrl(Astro.url);
+const dateObj = (() => {
+    if (pubDate instanceof Date && !isNaN(pubDate.getTime())) return pubDate;
+    const s = String(pubDate ?? '');
+    const d = new Date(/^\d{4}-\d{2}-\d{2}$/.test(s) ? `${s}T12:00:00` : s);
+    return isNaN(d.getTime()) ? new Date() : d;
+})();
+const isoDate = dateObj.toISOString().split('T')[0];
+---
+
+<!DOCTYPE html>
+<html lang={LOCALE_TAGS[lang]}>
+    <head>
+        <BaseHead title={`${title} — Leonardo Esparis`} description={description} lang={lang} image={image} />
+    </head>
+    <body>
+        <div class="page">
+            <div class="scanline" aria-hidden="true"></div>
+            <div class="glow" aria-hidden="true"></div>
+            <div class="container">
+                <SiteNav />
+                <main>
+                    <a class="back-link" href={lang === 'en' ? '/' : `/${lang}/`}>
+                        ← home
+                    </a>
+                    <article class="post">
+                        <header class="post-header">
+                            <time class="post-date" datetime={isoDate}>
+                                {dateObj.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+                            </time>
+                            <h1 class="post-title">{title}</h1>
+                            <p class="post-description">{description}</p>
+                        </header>
+                        <div class="post-body">
+                            <slot />
+                        </div>
+                    </article>
+                </main>
+                <Footer />
+            </div>
+        </div>
+        <GoogleAnalytics />
+    </body>
+</html>
+
+<style>
+    .page {
+        position: relative;
+        min-height: 100vh;
+        min-height: 100svh;
+        overflow: hidden;
+        background: var(--bg);
+    }
+    .scanline {
+        position: fixed;
+        inset: 0;
+        z-index: 50;
+        pointer-events: none;
+        background: repeating-linear-gradient(
+            0deg,
+            var(--scanline) 0px,
+            var(--scanline) 1px,
+            transparent 2px,
+            transparent 4px
+        );
+    }
+    .glow {
+        position: fixed;
+        top: -160px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 520px;
+        max-width: 100vw;
+        height: 420px;
+        z-index: 0;
+        pointer-events: none;
+        background: radial-gradient(circle, var(--glow), transparent 70%);
+        filter: blur(40px);
+        animation: pulseGlow 7s ease-in-out infinite;
+    }
+    .container {
+        position: relative;
+        z-index: 1;
+        max-width: var(--container);
+        margin: 0 auto;
+        padding: var(--gutter) var(--gutter) 56px;
+    }
+
+    .back-link {
+        display: inline-block;
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        color: var(--accent);
+        text-decoration: none;
+        letter-spacing: 0.06em;
+        margin-bottom: 2rem;
+        transition: opacity 0.15s ease;
+    }
+
+    .back-link:hover {
+        opacity: 0.7;
+    }
+
+    .post-header {
+        margin-bottom: 3rem;
+        padding-bottom: 1.5rem;
+        border-bottom: 1px solid var(--divider);
+    }
+
+    .post-date {
+        display: block;
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        color: var(--accent);
+        letter-spacing: 0.06em;
+        margin-bottom: 0.75rem;
+    }
+
+    .post-title {
+        font-size: clamp(1.5rem, 4vw, 2rem);
+        font-weight: 700;
+        color: var(--heading-strong);
+        line-height: 1.25;
+        margin-bottom: 0.75rem;
+        letter-spacing: -0.02em;
+    }
+
+    .post-description {
+        font-size: 1rem;
+        color: var(--text-muted);
+        line-height: 1.6;
+    }
+
+    /* Markdown body styles */
+    .post-body :global(h2) {
+        font-size: 1.25rem;
+        font-weight: 600;
+        color: var(--heading);
+        margin-top: 2.5rem;
+        margin-bottom: 0.75rem;
+        letter-spacing: -0.01em;
+    }
+
+    .post-body :global(h3) {
+        font-size: 1.05rem;
+        font-weight: 600;
+        color: var(--heading);
+        margin-top: 1.75rem;
+        margin-bottom: 0.5rem;
+    }
+
+    .post-body :global(p) {
+        color: var(--text);
+        line-height: 1.75;
+        margin-bottom: 1.25rem;
+    }
+
+    .post-body :global(ul),
+    .post-body :global(ol) {
+        color: var(--text);
+        line-height: 1.75;
+        margin-bottom: 1.25rem;
+        padding-left: 1.5rem;
+    }
+
+    .post-body :global(li) {
+        margin-bottom: 0.4rem;
+    }
+
+    .post-body :global(code) {
+        font-family: var(--font-mono);
+        font-size: 0.85em;
+        background: var(--surface-card);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        padding: 0.15em 0.4em;
+        color: var(--accent-bright);
+    }
+
+    .post-body :global(pre) {
+        background: var(--surface-card);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        padding: 1.25rem;
+        overflow-x: auto;
+        margin-bottom: 1.5rem;
+    }
+
+    .post-body :global(pre code) {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: 0.875rem;
+        color: var(--text-soft);
+    }
+
+    .post-body :global(blockquote) {
+        border-left: 3px solid var(--accent);
+        padding-left: 1.25rem;
+        margin: 1.5rem 0;
+        color: var(--text-muted);
+        font-style: italic;
+    }
+
+    .post-body :global(strong) {
+        color: var(--text-soft);
+        font-weight: 600;
+    }
+
+    .post-body :global(a) {
+        color: var(--accent);
+        text-decoration: underline;
+        text-underline-offset: 3px;
+        text-decoration-color: rgba(63, 224, 143, 0.4);
+        transition: text-decoration-color 0.15s ease;
+    }
+
+    .post-body :global(a:hover) {
+        text-decoration-color: var(--accent);
+    }
+
+    .post-body :global(hr) {
+        border: none;
+        border-top: 1px solid var(--divider);
+        margin: 2rem 0;
+    }
+
+    .post-body :global(table) {
+        width: 100%;
+        border-collapse: collapse;
+        margin-bottom: 1.5rem;
+        font-size: 0.9rem;
+    }
+
+    .post-body :global(th) {
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        color: var(--accent);
+        letter-spacing: 0.06em;
+        text-align: left;
+        padding: 0.6rem 0.75rem;
+        border-bottom: 1px solid var(--border);
+    }
+
+    .post-body :global(td) {
+        padding: 0.6rem 0.75rem;
+        border-bottom: 1px solid var(--divider);
+        color: var(--text);
+        vertical-align: top;
+    }
+</style>

--- a/src/pages/blog/post-mortems-are-awesome.mdx
+++ b/src/pages/blog/post-mortems-are-awesome.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../layouts/BlogPost.astro
 title: "Post-Mortems Are Awesome (And Here's Why You Should Love Them Too)"
-seoTitle: "Post-Mortems Are Awesome — Leonardo Esparis"
+seoTitle: "Post-Mortems Are Awesome: Root Cause & Blameless Teams"
 description: "Post-mortems aren't just incident paperwork. Done right, they're the most honest team conversation — and the best defense against repeating the same mistake."
 pubDate: "2026-06-21"
 ---

--- a/src/pages/blog/post-mortems-are-awesome.mdx
+++ b/src/pages/blog/post-mortems-are-awesome.mdx
@@ -1,7 +1,8 @@
 ---
 layout: ../../layouts/BlogPost.astro
 title: "Post-Mortems Are Awesome (And Here's Why You Should Love Them Too)"
-description: "Post-mortems aren't just paperwork after an outage. Done right, they're the most honest conversation a team can have — and a compounding investment in never breaking the same thing twice."
+seoTitle: "Post-Mortems Are Awesome — Leonardo Esparis"
+description: "Post-mortems aren't just incident paperwork. Done right, they're the most honest team conversation — and the best defense against repeating the same mistake."
 pubDate: "2026-06-21"
 ---
 

--- a/src/pages/blog/post-mortems-are-awesome.mdx
+++ b/src/pages/blog/post-mortems-are-awesome.mdx
@@ -1,0 +1,118 @@
+---
+layout: ../../layouts/BlogPost.astro
+title: "Post-Mortems Are Awesome (And Here's Why You Should Love Them Too)"
+description: "Post-mortems aren't just paperwork after an outage. Done right, they're the most honest conversation a team can have — and a compounding investment in never breaking the same thing twice."
+pubDate: "2026-06-21"
+---
+
+Something goes wrong. An API starts throwing 500s at 2am. A payment fails silently for two hours before anyone notices. A deploy flips the wrong feature flag in production. You scramble, fix it, breathe again.
+
+And then comes the question nobody wants to answer: *what do we do next?*
+
+Most teams move on. The incident fades. The fix ships. Life continues — until the same class of problem shows up three months later wearing a slightly different hat.
+
+The teams that don't repeat themselves do one thing differently: they write it all down, sit in a room (or a call), and figure out *why it really happened*. That's a post-mortem. And I've come to think it's one of the most valuable habits an engineering team can build.
+
+## The Blameless Frame That Makes Everything Else Work
+
+Before anything else: a post-mortem fails the moment it becomes about blame.
+
+The whole premise is that systems fail, not people. Engineers make decisions based on the information available to them at the time. If someone deployed on a Friday afternoon and something broke, the question isn't "why did they deploy on Friday" — it's "why did the system allow a Friday deploy to be risky in the first place?" and "why didn't we catch this before it hit production?"
+
+Blameless post-mortems aren't about letting people off the hook. They're about fixing the *system* so that no single person's judgment call can take down production. When people feel safe talking honestly, you get the real story. When they feel judged, you get a sanitized version that doesn't actually help anyone.
+
+This matters enough to say twice: if post-mortems in your team feel like performance reviews in disguise, they won't work. Fix that first.
+
+## Why It Happened: The Root Cause is Rarely the First Thing You Find
+
+The most common mistake in post-mortems is stopping too early on root cause analysis.
+
+The first answer is almost always a symptom. "A misconfigured environment variable caused the service to connect to the wrong database." Ok — *why* was the variable misconfigured? "The deploy script didn't validate it." Why didn't it validate it? "We didn't have a test for that path." Why not? "Because we added that variable six months ago and never updated the deploy checklist."
+
+That last answer is actually useful. Now you can fix the checklist, add a validation step, write a test. The environment variable wasn't the root cause — it was the final trigger in a chain.
+
+A useful technique here is the [Five Whys](https://en.wikipedia.org/wiki/Five_whys): ask "why" five times in succession. It sounds almost too simple, but it forces you past the surface-level narrative most people default to. You're not looking for the moment things went wrong — you're looking for the *gap* in your system, your process, or your tooling that made that moment possible.
+
+**Root cause categories worth asking about explicitly:**
+
+- **Human error** — Someone did something unexpected. Why was that action possible? Why wasn't it caught?
+- **Process gap** — A step was missing or not followed. Why didn't the process prevent this?
+- **Tooling failure** — A system didn't alert, didn't block, didn't catch it. Why not?
+- **Design weakness** — The architecture made this failure mode possible. What assumption was violated?
+- **Communication breakdown** — Context wasn't shared across teams. Why wasn't it?
+
+You're looking for the most *fixable* root cause given your current constraints — but be honest about whether the fix addresses the structural problem or just the proximate cause. Sometimes "add a validation gate to the deploy process" is enough; sometimes it's a band-aid over a deeper architectural gap that will surface again.
+
+## When It Happened: Impact Starts With Detection
+
+Knowing *when* something happened is not just a timestamp question. It's about understanding three distinct moments:
+
+1. **When did the failure start?** — The actual moment the system entered a bad state.
+2. **When was it detected?** — When did someone or something notice?
+3. **When was it mitigated?** — When did user impact stop?
+
+The gap between (1) and (2) is your **MTTD** (Mean Time To Detect) — how blind you were. The gap between (2) and (3) is your **MTTR** (Mean Time To Recover) — how fast your team can act under pressure. Both numbers tell you something specific about where to invest.
+
+A long detection lag usually means your monitoring or alerting is incomplete. A long response time usually means your runbooks are unclear, your on-call rotation isn't working, or the problem was genuinely hard to diagnose.
+
+Writing down the "when" with precision — down to the minute if you can — also helps reconstruct what was actually happening versus what people *thought* was happening. Human memory under stress is unreliable. The logs are more reliable than memory — pull them first. (Logs fail too — rotation, missing log levels, timezone mismatches — but they're still a better starting point than recollections.)
+
+## The Timeline: The Spine of the Post-Mortem
+
+The timeline is where a post-mortem earns its keep. It's a chronological reconstruction of everything that happened, from the first sign of trouble to the all-clear.
+
+A good timeline looks something like this:
+
+| Time (UTC) | Event |
+|---|---|
+| 02:14 | Error rate on `/payments` crosses 5% threshold |
+| 02:17 | PagerDuty alert fires, on-call engineer paged |
+| 02:24 | Engineer logs in, begins investigation |
+| 02:31 | Identified spike in DB connection timeouts |
+| 02:38 | Hypothesis: connection pool exhausted after deploy |
+| 02:45 | Rolled back deploy — error rate drops immediately |
+| 02:52 | Error rate back to baseline, incident resolved |
+| 03:10 | Root cause confirmed: new query missing index, causing full table scans under load |
+
+What makes timelines useful isn't just the events — it's the *decisions* and *hypotheses* made along the way. "Engineer suspected X, tried Y, ruled it out" is valuable. It shows the reasoning, not just the outcome. It helps future responders understand what paths not to take.
+
+Build the timeline from logs, not memory. Pull your monitoring dashboards, your Slack messages, your deploy history, your on-call tool's activity log. Stitch them together. You'll almost always find something surprising — a gap between when you thought you noticed something and when the logs say it started.
+
+## Action Items: The Part That Actually Changes Things
+
+Here's where most post-mortems die a quiet death. You write up the incident, list some action items, and six weeks later nobody can remember who owned what.
+
+Action items need three things to survive contact with reality:
+
+**1. A specific owner.** Not "the team" or "engineering." One named person. Teams diffuse accountability; individuals can be held to it.
+
+**2. A due date.** Not "soon" or "next sprint." A calendar date. Slip it onto a ticket. Put it on someone's plate. If it's not tracked somewhere people look every day, it won't get done.
+
+**3. A clear outcome.** Not "improve alerting." Something like "add a PagerDuty alert that fires when connection pool usage exceeds 80% for 2 minutes, owned by @me, due next Friday." That's a ticket. That's trackable. That's done or not done.
+
+Action items typically fall into a few categories:
+
+- **Detection**: How do we catch this faster next time? (New alerts, better dashboards, synthetic monitors)
+- **Response**: How do we respond better? (Runbooks, runbook drills, clearer escalation paths, better tooling)
+- **Prevention**: How do we stop it from happening at all? (Code fixes, architectural changes, process gates, automated tests)
+- **Communication**: How do we keep stakeholders in the loop better? (Status page updates, internal incident channels, escalation templates)
+
+The detection and response items are often the quickest wins. Prevention items tend to be more complex and longer-running. It's fine to have both — just be honest about the timeline for each.
+
+One more thing: not every action item needs to be big. Sometimes the right answer is "add a comment to this function explaining why it can't be called during peak hours." Sometimes it's "add this to the deploy checklist." Small actions that actually ship are worth more than ambitious ones that don't.
+
+## What Compounds Over Time
+
+The real return on post-mortems isn't visible in any single incident. It compounds.
+
+After a dozen post-mortems, patterns start to emerge. You'll notice that your database monitoring has been the root cause four times. That deploys on Fridays have a higher incident rate. That your on-call rotation has a consistent gap between 2am and 4am. These patterns are invisible unless you're writing them down.
+
+The best engineering teams I've seen treat their post-mortem archive as a knowledge base. New engineers read old post-mortems to understand how the system behaves under pressure. When a new incident happens, someone says "this feels like the connection pool thing from March" — and they're right, because they read that post-mortem.
+
+That's the actual ROI: institutional memory that doesn't live in one person's head, that survives attrition, that teaches the system's failure modes to everyone who joins.
+
+---
+
+Post-mortems aren't about the past. They're about making the future slightly more predictable than the present. And in complex systems, that's worth a lot.
+
+Write the timeline. Find the root cause. Ship the action items. Then read it again in six months and see what you missed.

--- a/src/pages/es/blog/post-mortems-are-awesome.mdx
+++ b/src/pages/es/blog/post-mortems-are-awesome.mdx
@@ -1,7 +1,8 @@
 ---
 layout: ../../../layouts/BlogPost.astro
 title: "Los post-mortems son geniales (y aquí te cuento por qué deberías amarlos también)"
-description: "Los post-mortems no son solo papeleo después de una caída. Bien hechos, son la conversación más honesta que puede tener un equipo — y una inversión compuesta para no romper lo mismo dos veces."
+seoTitle: "Los post-mortems son geniales — Leonardo Esparis"
+description: "Los post-mortems no son papeleo tras una caída. Bien hechos, son la conversación más honesta que puede tener tu equipo — y la mejor defensa contra repetir el mismo incidente."
 pubDate: "2026-06-21"
 ---
 

--- a/src/pages/es/blog/post-mortems-are-awesome.mdx
+++ b/src/pages/es/blog/post-mortems-are-awesome.mdx
@@ -1,0 +1,118 @@
+---
+layout: ../../../layouts/BlogPost.astro
+title: "Los post-mortems son geniales (y aquí te cuento por qué deberías amarlos también)"
+description: "Los post-mortems no son solo papeleo después de una caída. Bien hechos, son la conversación más honesta que puede tener un equipo — y una inversión compuesta para no romper lo mismo dos veces."
+pubDate: "2026-06-21"
+---
+
+Algo sale mal. Una API empieza a devolver 500s a las 2am. Un pago falla silenciosamente durante dos horas antes de que alguien se dé cuenta. Un deploy activa el feature flag equivocado en producción. Corres a arreglarlo, lo resuelves, respiras.
+
+Y entonces llega la pregunta que nadie quiere responder: *¿qué hacemos ahora?*
+
+La mayoría de los equipos siguen adelante. El incidente se olvida. El fix llega a producción. La vida continúa — hasta que el mismo tipo de problema aparece tres meses después con un disfraz ligeramente distinto.
+
+Los equipos que no repiten sus errores hacen una cosa diferente: lo escriben todo, se sientan (o entran a una llamada), y descubren *por qué ocurrió de verdad*. Eso es un post-mortem. Y me he convencido de que es uno de los hábitos más valiosos que puede cultivar un equipo de ingeniería.
+
+## El marco sin culpa que hace funcionar todo lo demás
+
+Antes que nada: un post-mortem fracasa en el momento en que se convierte en una búsqueda de culpables.
+
+La premisa entera es que los sistemas fallan, no las personas. Los ingenieros toman decisiones basándose en la información disponible en ese momento. Si alguien hizo un deploy un viernes por la tarde y algo se rompió, la pregunta no es "¿por qué hizo el deploy el viernes?" — sino "¿por qué el sistema permitía que un deploy de viernes fuera arriesgado en primer lugar?" y "¿por qué no lo atrapamos antes de que llegara a producción?"
+
+Los post-mortems sin culpa no son para eximirle a nadie de responsabilidad. Son para arreglar el *sistema* de modo que ninguna decisión individual pueda tumbar producción. Cuando la gente se siente segura para hablar con honestidad, obtienes la historia real. Cuando se siente juzgada, obtienes una versión sanitizada que no ayuda a nadie.
+
+Esto merece repetirse: si los post-mortems en tu equipo se sienten como evaluaciones de desempeño disfrazadas, no van a funcionar. Arregla eso primero.
+
+## Por qué ocurrió: la causa raíz rara vez es lo primero que encuentras
+
+El error más común en los post-mortems es detenerse demasiado pronto en el análisis de causa raíz.
+
+La primera respuesta casi siempre es un síntoma. "Una variable de entorno mal configurada hizo que el servicio se conectara a la base de datos equivocada." Ok — *¿por qué* estaba mal configurada? "El script de deploy no la validaba." ¿Por qué no la validaba? "No teníamos un test para esa ruta." ¿Por qué no? "Porque añadimos esa variable hace seis meses y nunca actualizamos el checklist de deploy."
+
+Esa última respuesta sí es útil. Ahora puedes arreglar el checklist, añadir un paso de validación, escribir el test. La variable de entorno no era la causa raíz — era el último eslabón de una cadena.
+
+Una técnica útil aquí es la de los [Cinco Por Qués](https://es.wikipedia.org/wiki/Los_cinco_%C2%BFPor_qu%C3%A9%3F): pregunta "por qué" cinco veces seguidas. Parece casi demasiado simple, pero te obliga a ir más allá de la narrativa superficial a la que la mayoría acude por defecto. No buscas el momento en que las cosas salieron mal — buscas la *brecha* en tu sistema, tu proceso o tus herramientas que hizo posible ese momento.
+
+**Categorías de causa raíz que vale la pena explorar explícitamente:**
+
+- **Error humano** — Alguien hizo algo inesperado. ¿Por qué esa acción era posible? ¿Por qué no se detectó?
+- **Brecha en el proceso** — Faltó un paso o no se siguió. ¿Por qué el proceso no lo previno?
+- **Fallo de herramientas** — Un sistema no alertó, no bloqueó, no lo capturó. ¿Por qué no?
+- **Debilidad de diseño** — La arquitectura hacía posible ese modo de fallo. ¿Qué suposición se violó?
+- **Fallo de comunicación** — El contexto no se compartió entre equipos. ¿Por qué no llegó?
+
+Buscas la causa raíz más *accionable* dados tus recursos actuales — pero sé honesto sobre si el fix resuelve el problema estructural o solo la causa próxima. A veces "añadir una puerta de validación al proceso de deploy" es suficiente; otras veces es un parche sobre un problema arquitectónico más profundo que volverá a aparecer.
+
+## Cuándo ocurrió: el impacto empieza por la detección
+
+Saber *cuándo* ocurrió algo no es solo una cuestión de timestamps. Se trata de entender tres momentos distintos:
+
+1. **¿Cuándo empezó el fallo?** — El momento exacto en que el sistema entró en un estado incorrecto.
+2. **¿Cuándo se detectó?** — ¿Cuándo lo notó alguien o algo?
+3. **¿Cuándo se mitigó?** — ¿Cuándo dejó de afectar a los usuarios?
+
+La brecha entre (1) y (2) es tu **MTTD** (Mean Time To Detect) — qué tan ciegos estabas. La brecha entre (2) y (3) es tu **MTTR** (Mean Time To Recover) — qué tan rápido puede actuar tu equipo bajo presión. Ambos números te dicen algo específico sobre dónde invertir.
+
+Un lag de detección largo suele significar que tu monitorización o alertas son incompletas. Un tiempo de respuesta largo suele indicar que tus runbooks no son claros, tu rotación de guardia no está funcionando, o el problema era genuinamente difícil de diagnosticar.
+
+Escribir el "cuándo" con precisión — hasta el minuto si puedes — también ayuda a reconstruir lo que realmente ocurrió versus lo que la gente *creía* que estaba pasando. La memoria humana bajo estrés no es fiable. Los logs son más fiables que la memoria — consúltalos primero. (Los logs también pueden fallar — rotación, niveles de log insuficientes, diferencias de zona horaria — pero siguen siendo un punto de partida mucho mejor que los recuerdos.)
+
+## La línea de tiempo: el eje vertebral del post-mortem
+
+La línea de tiempo es donde un post-mortem demuestra su valor. Es una reconstrucción cronológica de todo lo que ocurrió, desde la primera señal de problemas hasta que se dio el todo despejado.
+
+Una buena línea de tiempo tiene esta pinta:
+
+| Hora (UTC) | Evento |
+|---|---|
+| 02:14 | La tasa de error en `/payments` supera el umbral del 5% |
+| 02:17 | PagerDuty dispara alerta, se avisa al ingeniero de guardia |
+| 02:24 | El ingeniero se conecta e inicia la investigación |
+| 02:31 | Identificado pico en timeouts de conexión a la base de datos |
+| 02:38 | Hipótesis: pool de conexiones agotado tras el deploy |
+| 02:45 | Se revierte el deploy — la tasa de error cae inmediatamente |
+| 02:52 | Tasa de error vuelve a la línea base, incidente resuelto |
+| 03:10 | Causa raíz confirmada: query nueva sin índice, causando full table scans bajo carga |
+
+Lo que hace útil a la línea de tiempo no son solo los eventos — son las *decisiones* e *hipótesis* tomadas en el camino. "El ingeniero sospechó X, probó Y, lo descartó" tiene valor. Muestra el razonamiento, no solo el resultado. Ayuda a futuros respondedores a entender qué caminos no seguir.
+
+Construye la línea de tiempo a partir de los logs, no de la memoria. Abre tus dashboards de monitorización, mensajes de Slack, historial de deploys, logs de actividad de tu herramienta de guardia. Coselos juntos. Casi siempre encontrarás algo sorprendente — una brecha entre cuándo crees que notaste algo y cuándo los logs dicen que empezó.
+
+## Puntos de acción: la parte que realmente cambia las cosas
+
+Aquí es donde la mayoría de los post-mortems mueren silenciosamente. Escribes el incidente, listas algunos puntos de acción, y seis semanas después nadie recuerda quién era responsable de qué.
+
+Los puntos de acción necesitan tres cosas para sobrevivir al contacto con la realidad:
+
+**1. Un responsable específico.** No "el equipo" ni "ingeniería". Una persona con nombre y apellido. Los equipos diluyen la responsabilidad; los individuos pueden rendir cuentas.
+
+**2. Una fecha límite.** No "pronto" ni "en el próximo sprint". Una fecha en el calendario. Mételo en un ticket. Ponlo en el plato de alguien. Si no se rastrea en algún lugar que la gente mire cada día, no se hará.
+
+**3. Un resultado claro.** No "mejorar las alertas". Algo como "añadir una alerta en PagerDuty que se dispare cuando el uso del pool de conexiones supere el 80% durante 2 minutos, responsable @yo, fecha límite el próximo viernes". Eso es un ticket. Es rastreable. Se hizo o no se hizo.
+
+Los puntos de acción suelen caer en algunas categorías:
+
+- **Detección**: ¿Cómo detectamos esto más rápido la próxima vez? (Nuevas alertas, mejores dashboards, monitores sintéticos)
+- **Respuesta**: ¿Cómo respondemos mejor? (Runbooks, simulacros de runbook, rutas de escalada más claras, mejores herramientas)
+- **Prevención**: ¿Cómo evitamos que ocurra del todo? (Fixes en el código, cambios arquitectónicos, puertas de proceso, tests automatizados)
+- **Comunicación**: ¿Cómo mantenemos mejor informados a los stakeholders? (Actualizaciones en la status page, canales internos de incidentes, plantillas de escalada)
+
+Los ítems de detección y respuesta suelen ser las victorias más rápidas. Los de prevención tienden a ser más complejos y de mayor duración. Está bien tener ambos — solo sé honesto sobre el plazo de cada uno.
+
+Una cosa más: no todos los puntos de acción tienen que ser grandes. A veces la respuesta correcta es "añadir un comentario a esta función explicando por qué no se puede llamar en horas pico". A veces es "añadir esto al checklist de deploy". Las acciones pequeñas que sí se hacen valen más que las ambiciosas que no llegan a ningún sitio.
+
+## Lo que se acumula con el tiempo
+
+El retorno real de los post-mortems no es visible en ningún incidente individual. Se acumula.
+
+Después de una docena de post-mortems, empiezan a aparecer patrones. Notarás que la monitorización de tu base de datos ha sido la causa raíz cuatro veces. Que los deploys los viernes tienen una tasa de incidentes más alta. Que tu rotación de guardia tiene una brecha consistente entre las 2am y las 4am. Estos patrones son invisibles a menos que los estés escribiendo.
+
+Los mejores equipos de ingeniería que he visto tratan su archivo de post-mortems como una base de conocimiento. Los ingenieros nuevos leen post-mortems anteriores para entender cómo se comporta el sistema bajo presión. Cuando ocurre un nuevo incidente, alguien dice "esto se parece al problema del pool de conexiones de marzo" — y tiene razón, porque leyó ese post-mortem.
+
+Ese es el ROI real: memoria institucional que no vive en la cabeza de una sola persona, que sobrevive a la rotación del equipo, que enseña los modos de fallo del sistema a todos los que se incorporan.
+
+---
+
+Los post-mortems no son sobre el pasado. Son sobre hacer el futuro ligeramente más predecible que el presente. Y en sistemas complejos, eso vale mucho.
+
+Escribe la línea de tiempo. Encuentra la causa raíz. Entrega los puntos de acción. Luego léelo de nuevo en seis meses y mira lo que te perdiste.

--- a/src/pages/es/blog/post-mortems-are-awesome.mdx
+++ b/src/pages/es/blog/post-mortems-are-awesome.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/BlogPost.astro
 title: "Los post-mortems son geniales (y aquí te cuento por qué deberías amarlos también)"
-seoTitle: "Los post-mortems son geniales — Leonardo Esparis"
+seoTitle: "Los post-mortems son geniales — Análisis de causa raíz"
 description: "Los post-mortems no son papeleo tras una caída. Bien hechos, son la conversación más honesta que puede tener tu equipo — y la mejor defensa contra repetir el mismo incidente."
 pubDate: "2026-06-21"
 ---

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -79,6 +79,18 @@ svg {
 	max-width: 100%;
 }
 
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
 :focus-visible {
 	outline: 2px solid var(--accent-bright);
 	outline-offset: 3px;


### PR DESCRIPTION
- Add BlogPost layout with back link, date, and prose styles
- Add EN and ES versions of the post-mortems article
- Wire Writing section into HomeContent
- Fix date parsing for Astro v4 MDX frontmatter (frontmatter nested prop)
- Language switcher uses path prefix only, no slug translation